### PR TITLE
fix: correct neutron star draw method name

### DIFF
--- a/backups/sim_v300.py
+++ b/backups/sim_v300.py
@@ -253,7 +253,7 @@ class NEUTRON_STAR:
         self.pulse_strength = NEUTRON_STAR_PULSE_STRENGTH
         self.time_since_last_pulse = 0
 
-    def draw_neotron_star(self, screen):
+    def draw_neutron_star(self, screen):
         pygame.draw.circle(screen, NEUTRON_STAR_COLOR, (self.x, self.y), self.radius)
 
     def pulse_gravity_from_neutron_star(self, list_of_molecular_clouds, delta_time):
@@ -444,7 +444,7 @@ def run_simulation():
                 neutron_star.update_position_of_entities_from_pulse(list_of_molecular_clouds, delta_time)
                 neutron_star.pulse_gravity_from_neutron_star(list_of_molecular_clouds, delta_time)
                 neutron_star.decay_neutron_star()
-                neutron_star.draw_neotron_star(screen)
+                neutron_star.draw_neutron_star(screen)
                 if neutron_star.mass <= BLACK_HOLE_DECAY_THRESHOLD:
                     decay_neutronstars.append(neutron_star)
             for decay_neutronstar in decay_neutronstars.copy():

--- a/sim/sim.py
+++ b/sim/sim.py
@@ -344,7 +344,7 @@ class NEUTRON_STAR:
         self.pulse_color_state = 0  # 0: normal color, 1: white during pulse
         self.pulse_color_duration = 0.1  # Duration of white color in seconds
 
-    def draw_neotron_star(self, screen):
+    def draw_neutron_star(self, screen):
         if self.selected:
             highlight_color = (255, 165, 0)
             pygame.draw.circle(screen, highlight_color, (int(self.x), int(self.y)), self.radius)
@@ -893,7 +893,7 @@ def draw_simulation(screen, ring, list_of_molecular_clouds, list_of_black_holes,
         black_hole.draw_black_hole(screen)
 
     for neutron_star in list_of_neutron_stars:
-        neutron_star.draw_neotron_star(screen)
+        neutron_star.draw_neutron_star(screen)
 
 
 def draw_ui(screen, font, current_year, selected_entity, sub_window_active):

--- a/tests/test_neutron_star.py
+++ b/tests/test_neutron_star.py
@@ -1,0 +1,72 @@
+import sys
+import types
+import unittest
+
+# Create minimal pygame stub
+class DummySurface:
+    def __init__(self, size, flags=0):
+        self.size = size
+    def blit(self, source, pos):
+        pass
+
+class DummyFont:
+    def render(self, *args, **kwargs):
+        return DummySurface((10, 10))
+
+def SysFont(name, size):
+    return DummyFont()
+
+class DummyRect:
+    def __init__(self, x, y, w, h):
+        self.x = x
+        self.y = y
+        self.width = w
+        self.height = h
+    def inflate(self, dx, dy):
+        return DummyRect(self.x, self.y, self.width + dx, self.height + dy)
+    def collidepoint(self, x, y):
+        return False
+
+pygame_stub = types.SimpleNamespace(
+    Surface=DummySurface,
+    Rect=DummyRect,
+    SRCALPHA=0,
+    init=lambda: None,
+    display=types.SimpleNamespace(set_caption=lambda *a, **k: None,
+                                  set_mode=lambda *a, **k: DummySurface((10,10))),
+    font=types.SimpleNamespace(SysFont=SysFont),
+    draw=types.SimpleNamespace(circle=lambda *a, **k: None,
+                               rect=lambda *a, **k: None),
+)
+
+sys.modules['pygame'] = pygame_stub
+
+# Stub out matplotlib modules used in sim
+matplotlib_stub = types.ModuleType('matplotlib')
+pyplot_stub = types.ModuleType('matplotlib.pyplot')
+backend_stub = types.ModuleType('matplotlib.backends')
+agg_stub = types.ModuleType('matplotlib.backends.backend_agg')
+matplotlib_stub.pyplot = pyplot_stub
+backend_stub.backend_agg = agg_stub
+sys.modules['matplotlib'] = matplotlib_stub
+sys.modules['matplotlib.pyplot'] = pyplot_stub
+sys.modules['matplotlib.backends'] = backend_stub
+sys.modules['matplotlib.backends.backend_agg'] = agg_stub
+
+import os
+os.environ.setdefault('SIMCRAFT_DATA', '.')
+
+from sim.sim import NEUTRON_STAR
+
+class TestNeutronStarDraw(unittest.TestCase):
+    def test_draw_neutron_star(self):
+        pygame_stub.init()
+        surface = pygame_stub.Surface((10, 10))
+        ns = NEUTRON_STAR(5, 5, 1.0)
+        self.assertTrue(hasattr(ns, 'draw_neutron_star'))
+        self.assertFalse(hasattr(ns, 'draw_neotron_star'))
+        ns.draw_neutron_star(surface)
+        self.assertIsInstance(surface, DummySurface)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- rename `draw_neotron_star` to `draw_neutron_star`
- update call site in `sim.py`
- update backup version for consistency
- add a minimal unit test to check new method name

## Testing
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_6850acb2c8808328946f5e4c3b9bd4f2