### PR TITLE
fix: correct neutron star draw method name

### DIFF
--- a/backups/sim_v300.py
+++ b/backups/sim_v300.py
@@ -253,7 +253,7 @@ class NEUTRON_STAR:
         self.pulse_strength = NEUTRON_STAR_PULSE_STRENGTH
         self.time_since_last_pulse = 0
 
-    def draw_neotron_star(self, screen):
+    def draw_neutron_star(self, screen):
         pygame.draw.circle(screen, NEUTRON_STAR_COLOR, (self.x, self.y), self.radius)
 
     def pulse_gravity_from_neutron_star(self, list_of_molecular_clouds, delta_time):
@@ -444,7 +444,7 @@ def run_simulation():
                 neutron_star.update_position_of_entities_from_pulse(list_of_molecular_clouds, delta_time)
                 neutron_star.pulse_gravity_from_neutron_star(list_of_molecular_clouds, delta_time)
                 neutron_star.decay_neutron_star()
-                neutron_star.draw_neotron_star(screen)
+                neutron_star.draw_neutron_star(screen)
                 if neutron_star.mass <= BLACK_HOLE_DECAY_THRESHOLD:
                     decay_neutronstars.append(neutron_star)
             for decay_neutronstar in decay_neutronstars.copy():

--- a/sim/sim.py
+++ b/sim/sim.py
@@ -344,7 +344,7 @@ class NEUTRON_STAR:
         self.pulse_color_state = 0  # 0: normal color, 1: white during pulse
         self.pulse_color_duration = 0.1  # Duration of white color in seconds
 
-    def draw_neotron_star(self, screen):
+    def draw_neutron_star(self, screen):
         if self.selected:
             highlight_color = (255, 165, 0)
             pygame.draw.circle(screen, highlight_color, (int(self.x), int(self.y)), self.radius)
@@ -893,7 +893,7 @@ def draw_simulation(screen, ring, list_of_molecular_clouds, list_of_black_holes,
         black_hole.draw_black_hole(screen)
 
     for neutron_star in list_of_neutron_stars:
-        neutron_star.draw_neotron_star(screen)
+        neutron_star.draw_neutron_star(screen)
 
 
 def draw_ui(screen, font, current_year, selected_entity, sub_window_active):


### PR DESCRIPTION
## Summary
- rename neutron star drawing function
- update call sites and legacy backup
- drop stray test file

## Testing
- `python -m unittest discover -s tests` *(fails: ImportError: Start directory is not importable: 'tests')*

------
https://chatgpt.com/codex/tasks/task_e_6850acb2c8808328946f5e4c3b9bd4f2